### PR TITLE
Use current value of embedId ref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const ShoutoutEmbed = ({ url }) => {
         'https://platform.shoutout.so',
         ''
       )}`}
-      id={embedId}
+      id={embedId.current}
       src={`https://platform.shoutout.so/${url}`}
       frameBorder='0'
       scrolling='yes'


### PR DESCRIPTION
Currently the `embedId` that is passed to the `id` property of `IframeResizer` is a mutable object `{ current: 'some-generated-id' }` and thus always results in HTML a la `id="[object Object]"`, which makes it impossible to use two instances of this component on the same page, as the resizing will break.